### PR TITLE
newer version of which outputs to stderr, 2> /dev/null suppresses that 

### DIFF
--- a/bin/pzc
+++ b/bin/pzc
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+
 PAZCAL_DIR=/home/nickie/pazcal
 BIN_DIR=$PAZCAL_DIR/bin
 INCLUDE_DIR=$PAZCAL_DIR/include
 
-CC=`which colorgcc` || CC=gcc
+CC=`which colorgcc 2> /dev/null` || CC=gcc
 CFLAGS="-std=gnu99 -Wall -Wextra -Werror -I $INCLUDE_DIR -include pazcal.h"
 
 MAIN=`$BIN_DIR/pzcheck $*` \


### PR DESCRIPTION
Unless otherwise intended pzc shouldn't complain if colorgcc is not available right?
