### PR TITLE
Fix tab character detection for older sed versions

### DIFF
--- a/bin/pzcheck
+++ b/bin/pzcheck
@@ -12,7 +12,7 @@ while [ "$1" != "" ]; do
         *)
             cat "$1" \
                 | grep PROGRAM \
-                | sed 's/.*PROGRAM[ \t]*\([A-Za-z0-9_]*\).*/\1/' \
+                | sed 's/.*PROGRAM[[:blank:]]*\([A-Za-z0-9_]*\).*/\1/' \
                 | sed 's/^main$/__pazcal_main/'
             shift
             ;;


### PR DESCRIPTION
'\t' on older sed versions (such as the one MacOS is using) gets recognized as '\' and 't'.
Therefore, running the checker on a program with the line `PROGRAM threedig()` produces the following (false) output:

```
$ pzcheck 03-threedig.pzc
hreedig
```

which then fails to compile (due to undefined reference). This PR fixes the problem.
